### PR TITLE
add a filter to tabs

### DIFF
--- a/background.js
+++ b/background.js
@@ -84,7 +84,7 @@ var main = function() {
   updateSettings();
   chrome.browserAction.onClicked.addListener(function() {
     chrome.tabs.query({active: true}, function(tabs) {
-      var tab = tabs[0];
+      var tab = tabs.filter((tab) => tab.url.indexOf('bluecore') > -1)[0];
 
       chrome.tabs.executeScript(tab.id, {
         file: 'commands/get_domain.js'

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
     "tabs",
     "cookies",
     "notifications",
-    "<all_urls>"
+    "<all_urls>",
+    "*://*/*"
   ],
   "icons": {
     "16": "img/icon.png",


### PR DESCRIPTION
I had an issue using the extension. It turned out that I had too many tabs and windows opened, so it made it a little difficult to pick out the bluecore tab, which might not be tab[0]. This doesn't fix the problem completely, but it does a filter to check the url